### PR TITLE
Added the ability to export decorations from the selected save

### DIFF
--- a/gui/mhwisaveeditor.cpp
+++ b/gui/mhwisaveeditor.cpp
@@ -1,6 +1,3 @@
-#include <iostream>
-#include <fstream>
-
 #include "mhwisaveeditor.h"
 #include "ui_mhwisaveeditor.h"
 
@@ -10,6 +7,8 @@
 #include <QDesktopServices>
 #include <QGridLayout>
 #include <QStyleFactory>
+
+#include <fstream>
 
 // Encryption
 #include "../crypto/iceborne_crypt.h"

--- a/gui/mhwisaveeditor.h
+++ b/gui/mhwisaveeditor.h
@@ -34,6 +34,7 @@ public slots:
   void Save();
   void SaveAs();
   void Dump(int number);
+  void ExportDecoList();
 
   void Backup();
   void Restore();

--- a/gui/mhwisaveeditor.ui
+++ b/gui/mhwisaveeditor.ui
@@ -82,7 +82,6 @@
     <addaction name="actionOpenSaveLocation"/>
     <addaction name="separator"/>
     <addaction name="menuDump"/>
-    <addaction name="actionExportDecoList"/>
     <addaction name="separator"/>
     <addaction name="actionBackup"/>
     <addaction name="actionRestore"/>
@@ -126,7 +125,18 @@
     <property name="title">
      <string comment="Tools menu" extracomment="Contains editor settings and shortcuts.">Tools</string>
     </property>
+    <widget class="QMenu" name="menuExport">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Export</string>
+     </property>
+     <addaction name="actionExportDecoList"/>
+    </widget>
     <addaction name="actionSettings"/>
+    <addaction name="separator"/>
+    <addaction name="menuExport"/>
     <addaction name="separator"/>
     <addaction name="actionUncraftEquipment"/>
    </widget>
@@ -676,6 +686,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionExportDecoList</sender>
+   <signal>triggered()</signal>
+   <receiver>MHWISaveEditor</receiver>
+   <slot>ExportDecoList()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>577</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>Open()</slot>
@@ -692,5 +718,6 @@
   <slot>UncraftUnusedEquipment()</slot>
   <slot>DebugFixEquipmentBoxRef()</slot>
   <slot>DebugRemoveUnobtainableItems()</slot>
+  <slot>ExportDecoList()</slot>
  </slots>
 </ui>

--- a/gui/mhwisaveeditor.ui
+++ b/gui/mhwisaveeditor.ui
@@ -82,6 +82,7 @@
     <addaction name="actionOpenSaveLocation"/>
     <addaction name="separator"/>
     <addaction name="menuDump"/>
+    <addaction name="actionExportDecoList"/>
     <addaction name="separator"/>
     <addaction name="actionBackup"/>
     <addaction name="actionRestore"/>
@@ -441,6 +442,11 @@
   <action name="actionRemoveUnobtainableItems">
    <property name="text">
     <string comment="Debug-&gt;Fixes-&gt;Remove Unobtainable Items" extracomment="Removes all unobtainable items from the player inventory and item box.">Remove Unobtainable Items</string>
+   </property>
+  </action>
+  <action name="actionExportDecoList">
+   <property name="text">
+    <string>Export Deco List</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
New menu option added to export the decorations of the selected save in a JSON format accepted be the mhw.wiki-db.com armor set searcher as this is the only active armor set searcher that I am aware of. Figured I'd give ya'll a PR even though this may not be the most useful anymore.