### PR TITLE
Fix to deco exports

### DIFF
--- a/gui/mhwisaveeditor.cpp
+++ b/gui/mhwisaveeditor.cpp
@@ -291,6 +291,7 @@ void MHWISaveEditor::ExportDecoList()
     }
   }
 
+  // TODO: Load these from: chunk/common/item/skillGemParam.sgpa
   // Deco's slotted into equipement are not refered to by there actual
   // item ID. Instead the seem to be stored as indices of a deco a flat
   // deco list. So we make this list by running through all item ID's
@@ -301,11 +302,12 @@ void MHWISaveEditor::ExportDecoList()
   uint32 deco_map_idx = 0;
   for (uint32 i = 0; i < itemDB->count(); i++)
   {
-    auto item_name = itemDB->ItemName(i);
-    if (item_name.contains("Jewel")) {
-      deco_id_map[deco_map_idx] = i + 1;
-      deco_map_idx++;
-    }
+    itm_entry* info = itemDB->GetItemById(i);
+    if (info->type != (u32)itemCategory::Decoration) continue;
+    if (!(info->flags & (u32)itemFlag::CustomObtainable)) continue;
+
+    deco_id_map[deco_map_idx] = i;
+    deco_map_idx++;
   }
 
   // Now that we have our flat deco list, we can run through the
@@ -318,7 +320,7 @@ void MHWISaveEditor::ExportDecoList()
       {
         auto equipment = &current_save->equipment[i];
         auto deco_idx = equipment->decos[j];
-        if (deco_idx < COUNTOF(mhw_storage::decorations))
+        if (deco_idx < deco_map_idx)
         {
           auto deco_name = itemDB->ItemName(deco_id_map[deco_idx]);
 

--- a/gui/mhwisaveeditor.cpp
+++ b/gui/mhwisaveeditor.cpp
@@ -280,14 +280,14 @@ void MHWISaveEditor::ExportDecoList()
   // First we fill the deco map with the amount of deco's that
   // are in the player storage. This DOES NOT include the deco's
   // that have been slotted in equipment.
-  std::map<QString, uint32> equiped_deco_map;
+  std::map<QString, uint32> decoration_counts;
   for (uint32 i = 0; i < COUNTOF(mhw_storage::decorations); i++)
   {
     if (deco_list[i].amount > 0)
     {
       auto deco_name = itemDB->ItemName(deco_list[i].id);
 
-      equiped_deco_map[deco_name] = deco_list[i].amount;
+      decoration_counts[deco_name] = deco_list[i].amount;
     }
   }
 
@@ -324,13 +324,16 @@ void MHWISaveEditor::ExportDecoList()
         {
           auto deco_name = itemDB->ItemName(deco_id_map[deco_idx]);
 
-          if (equiped_deco_map.find(deco_name) != equiped_deco_map.end())
+          if (decoration_counts.find(deco_name) != decoration_counts.end())
           {
-            equiped_deco_map[deco_name]++;
+            decoration_counts[deco_name]++;
           }
           else {
-            equiped_deco_map[deco_name] = 1;
+            decoration_counts[deco_name] = 1;
           }
+        }
+        else {
+          // TODO: Logging
         }
       }
     }
@@ -342,7 +345,7 @@ void MHWISaveEditor::ExportDecoList()
   deco_file << "{\n";
 
   uint32 i = 0;
-  for (auto const& pair : equiped_deco_map)
+  for (auto const& pair : decoration_counts)
   {
     auto deco_name = pair.first;
     auto deco_count = pair.second;


### PR DESCRIPTION
Sorry for another drive by PR. Had to rework how deco exporting works. Turns out if a deco is slotted into equipment, then it does not show up in the players deco inventory.

This change now goes through all the player equipment and adds the decos that are included in there.