### PR TITLE
Add Hunter Rank XP field

### DIFF
--- a/gui/info/hunterinfo.cpp
+++ b/gui/info/hunterinfo.cpp
@@ -49,6 +49,15 @@ void HunterInfo::PalicoNameChange(const QString& text)
   SetStr(palicoName, text);
 }
 
+void HunterInfo::HunterXPChange(int value)
+{
+  MHW_LOADING_GUARD;
+  mhw_save_slot* mhwSaveSlot = MHW_SaveSlot();
+
+  u32 hunterXp = value;
+  mhwSaveSlot->hunter.hunter_rank_xp = hunterXp;
+}
+
 void HunterInfo::ZennyChange(int value)
 {
   MHW_LOADING_GUARD;
@@ -144,6 +153,8 @@ void HunterInfo::Load(mhw_save_raw* mhwSave, int slotIndex)
 
   str64 hunterName = {};
   str64 palicoName = {};
+  u32 hunterXp = mhwSaveSlot->hunter.hunter_rank_xp;
+
   u32 zeni = mhwSaveSlot->hunter.zeni;
   u32 researchPoints = mhwSaveSlot->hunter.research_points;
   u32 steamworksFuel = mhwSaveSlot->steamworks_stored_fuel;
@@ -158,10 +169,13 @@ void HunterInfo::Load(mhw_save_raw* mhwSave, int slotIndex)
 
   ui->edtHunterName->setText(hunterName);
   ui->edtPalicoName->setText(palicoName);
+  ui->spnHunterXP->setValue(hunterXp);
   ui->spnZenny->setValue(zeni);
   ui->spnResearchPoints->setValue(researchPoints);
   ui->spnSteamworksFuel->setValue(steamworksFuel);
   ui->spnPlaytime->setValue(playtime);
+
+  connect(ui->spnHunterXP, SIGNAL(valueChanged(int)), this, SLOT(HunterXPChange(int)));
 
   QMapIterator<QSpinBox*, u8> i(regionIndexMapping);
   while (i.hasNext()) {

--- a/gui/info/hunterinfo.h
+++ b/gui/info/hunterinfo.h
@@ -14,6 +14,7 @@ class HunterInfo : public QWidget, public SaveLoader
 public slots:
   void HunterNameChange(const QString& text);
   void PalicoNameChange(const QString& text);
+  void HunterXPChange(int value);
   void ZennyChange(int value);
   void ResearchPointsChange(int value);
   void SteamworksFuelChange(int value);

--- a/gui/info/hunterinfo.ui
+++ b/gui/info/hunterinfo.ui
@@ -42,14 +42,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="lblZenny">
      <property name="text">
       <string comment="Label for zenny.">Zenny:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QSpinBox" name="spnZenny">
      <property name="accelerated">
       <bool>true</bool>
@@ -65,14 +65,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="lblResearchPoints">
      <property name="text">
       <string comment="Label for research points.">Research Points:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="QSpinBox" name="spnResearchPoints">
      <property name="accelerated">
       <bool>true</bool>
@@ -88,14 +88,14 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="lblSteamworksFuel">
      <property name="text">
       <string comment="Label for steamworks fuel.">Steamworks Fuel:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QSpinBox" name="spnSteamworksFuel">
      <property name="accelerated">
       <bool>true</bool>
@@ -111,7 +111,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="spnPlaytime">
      <property name="accelerated">
       <bool>true</bool>
@@ -130,7 +130,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QGroupBox" name="grpGuidingLands">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -268,10 +268,24 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="lblPlaytime">
      <property name="text">
       <string comment="Label for hunter playtime.">Playtime:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="lblHunterXP">
+     <property name="text">
+      <string>Hunter Rank XP</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="spnHunterXP">
+     <property name="maximum">
+      <number>999999999</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This adds an extra field to the UI, where users can edit their Hunter Rank XP. This enables people to rapidly progress between the late High Rank assignments without grinding. After editing, users will have to gain at least 1 XP in order to make the game update the Hunter Rank.